### PR TITLE
Refactor LaraClient Streaming Internals and Unify Stream Handling

### DIFF
--- a/src/main/java/com/translated/lara/net/ClientResponse.java
+++ b/src/main/java/com/translated/lara/net/ClientResponse.java
@@ -5,8 +5,8 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.translated.lara.errors.LaraApiConnectionException;
-import com.translated.lara.errors.LaraApiException;
 import com.translated.lara.errors.LaraApiConnectionTimeoutException;
+import com.translated.lara.errors.LaraApiException;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -28,8 +28,8 @@ public class ClientResponse {
     private final String rawData;
     private final String contentType;
 
-    ClientResponse(Gson gson, HttpURLConnection connection) throws LaraApiConnectionException {
-        this.gson = gson;
+    static ClientResponse fromConnection(Gson gson, HttpURLConnection connection) throws LaraApiConnectionException {
+        String contentType = connection.getContentType();
 
         int httpStatus;
         try {
@@ -42,20 +42,15 @@ public class ClientResponse {
 
         boolean isSuccessful = httpStatus >= 200 && httpStatus < 300;
 
-        this.contentType = connection.getContentType();
-
         if (isSuccessful && contentType != null && contentType.contains("text/csv")) {
             try (BufferedReader reader = new BufferedReader(
                     new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8))) {
-                this.rawData = reader.lines().collect(Collectors.joining("\n"));
-                this.data = null;
-                this.error = null;
+                String csvBody = reader.lines().collect(Collectors.joining("\n"));
+                return new ClientResponse(gson, contentType, csvBody);
             } catch (IOException e) {
                 throw new LaraApiConnectionException("Failed to get response stream", e);
             }
         } else {
-            this.rawData = null;
-
             JsonElement response;
             try (Reader reader = new InputStreamReader(isSuccessful ? connection.getInputStream() : connection.getErrorStream(), StandardCharsets.UTF_8)) {
                 JsonObject root = JsonParser.parseReader(reader).getAsJsonObject();
@@ -64,25 +59,41 @@ public class ClientResponse {
                 throw new LaraApiConnectionException("Failed to get response stream", e);
             }
 
-            if (isSuccessful) {
-                this.error = null;
-                this.data = response;
-            } else {
-                String type = "UnknownError";
-                String message = "An unknown error occurred";
-
-                if (response != null) {
-                    JsonObject error = response.getAsJsonObject();
-                    if (error.has("type"))
-                        type = error.get("type").getAsString();
-                    if (error.has("message"))
-                        message = error.get("message").getAsString();
-                }
-
-                this.error = new LaraApiException(httpStatus, type, message);
-                this.data = null;
-            }
+            return new ClientResponse(gson, httpStatus, contentType, response);
         }
+    }
+
+    ClientResponse(Gson gson, int httpStatus, String contentType, JsonElement response) {
+        this.gson = gson;
+        this.contentType = contentType;
+        this.rawData = null;
+
+        if (httpStatus >= 200 && httpStatus < 300) {
+            this.error = null;
+            this.data = response;
+        } else {
+            String type = "UnknownError";
+            String message = "An unknown error occurred";
+
+            if (response != null) {
+                JsonObject error = response.getAsJsonObject();
+                if (error.has("type"))
+                    type = error.get("type").getAsString();
+                if (error.has("message"))
+                    message = error.get("message").getAsString();
+            }
+
+            this.error = new LaraApiException(httpStatus, type, message);
+            this.data = null;
+        }
+    }
+
+    ClientResponse(Gson gson, String contentType, String csvBody) {
+        this.gson = gson;
+        this.contentType = contentType;
+        this.rawData = csvBody;
+        this.data = null;
+        this.error = null;
     }
 
     public <T> T as(Class<T> clazz) throws LaraApiException {

--- a/src/main/java/com/translated/lara/net/LaraClient.java
+++ b/src/main/java/com/translated/lara/net/LaraClient.java
@@ -206,10 +206,6 @@ public class LaraClient {
             BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
 
             return reader.lines()
-                    .map(line -> {
-                        System.out.println("STREAM LINE: " + line);
-                        return line;
-                    })
                     .filter(line -> !line.trim().isEmpty())
                     .map(line -> parseStreamLine(contentType, responseCode, line))
                     .onClose(() -> {

--- a/src/main/java/com/translated/lara/net/LaraClient.java
+++ b/src/main/java/com/translated/lara/net/LaraClient.java
@@ -1,15 +1,9 @@
 package com.translated.lara.net;
 
-import com.google.gson.FieldNamingPolicy;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
+import com.google.gson.*;
 import com.translated.lara.Credentials;
 import com.translated.lara.Version;
 import com.translated.lara.errors.LaraApiConnectionException;
-import com.translated.lara.errors.LaraApiException;
 import com.translated.lara.errors.LaraException;
 import com.translated.lara.net.json.DocumentStatusTypeAdapter;
 import com.translated.lara.net.json.TextResultValueTypeAdapter;
@@ -18,12 +12,7 @@ import com.translated.lara.translator.TextResult;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
+import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -133,17 +122,19 @@ public class LaraClient {
         return request("PUT", path, params, files, headers);
     }
 
-    public Stream<TextResult> postAndGetStream(String path, Map<String, Object> params) throws LaraException {
+    public Stream<ClientResponse> postAndGetStream(String path, Map<String, Object> params) throws LaraException {
         return postAndGetStream(path, params, null, null);
     }
-    public Stream<TextResult> postAndGetStream(String path, Map<String, Object> params, Map<String, String> headers) throws LaraException {
+
+    public Stream<ClientResponse> postAndGetStream(String path, Map<String, Object> params, Map<String, String> headers) throws LaraException {
         return postAndGetStream(path, params, null, headers);
     }
-    public Stream<TextResult> postAndGetStream(String path, Map<String, Object> params, Map<String, File> files, Map<String, String> headers) throws LaraException {
-        return requestStream("POST", path, params, files, headers).map(this::parseTextResult);
+
+    public Stream<ClientResponse> postAndGetStream(String path, Map<String, Object> params, Map<String, File> files, Map<String, String> headers) throws LaraException {
+        return requestStream("POST", path, params, files, headers);
     }
 
-    private Stream<JsonElement> requestStream(String method, String path, Map<String, Object> params, Map<String, File> files, Map<String, String> headers) throws LaraException {
+    private Stream<ClientResponse> requestStream(String method, String path, Map<String, Object> params, Map<String, File> files, Map<String, String> headers) throws LaraException {
         path = normalizePath(path);
         params = prune(params);
         files = prune(files);
@@ -210,21 +201,26 @@ public class LaraClient {
                 throw new LaraApiConnectionException("HTTP error code: " + responseCode);
             }
 
+            String contentType = connection.getContentType();
             InputStream inputStream = connection.getInputStream();
             BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
 
             return reader.lines()
-                .filter(line -> !line.trim().isEmpty())
-                .map(line -> parseStreamLine(line, responseCode))
-                .onClose(() -> {
-                    try {
-                        reader.close();
-                    } catch (IOException e) {
-                        // Ignore close errors
-                    } finally {
-                        connection.disconnect();
-                    }
-                });
+                    .map(line -> {
+                        System.out.println("STREAM LINE: " + line);
+                        return line;
+                    })
+                    .filter(line -> !line.trim().isEmpty())
+                    .map(line -> parseStreamLine(contentType, responseCode, line))
+                    .onClose(() -> {
+                        try {
+                            reader.close();
+                        } catch (IOException e) {
+                            // Ignore close errors
+                        } finally {
+                            connection.disconnect();
+                        }
+                    });
 
         } catch (IOException e) {
             throw new LaraApiConnectionException("Streaming request failed: " + e.getMessage(), e);
@@ -285,7 +281,7 @@ public class LaraClient {
                 }
             }
 
-            return new ClientResponse(gson, connection);
+            return ClientResponse.fromConnection(gson, connection);
         } catch (IOException e) {
             throw new LaraApiConnectionException("Failed to connect to URL: " + baseUrl + path, e);
         }
@@ -358,56 +354,13 @@ public class LaraClient {
         }
     }
 
-    private JsonElement parseStreamLine(String line, int responseCode) {
-        JsonElement jsonElement;
-        try {
-            jsonElement = JsonParser.parseString(line);
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to parse streaming response line: " + line, e);
-        }
+    private ClientResponse parseStreamLine(String contentType, int responseCode, String line) {
+        JsonObject root = JsonParser.parseString(line).getAsJsonObject();
 
-        if (!jsonElement.isJsonObject()) {
-            return jsonElement;
-        }
+        int httpStatus = root.has("status") ? root.get("status").getAsInt() : responseCode;
+        JsonElement response = root.has("content") ? root.get("content") : root.get("error");
 
-    JsonObject jsonObject = jsonElement.getAsJsonObject();
-    int status = jsonObject.has("status") ? jsonObject.get("status").getAsInt() : responseCode;
-
-    if (status < 200 || status >= 300) {
-        throw new RuntimeException(buildStreamingApiException(status, jsonObject));
-    }
-
-    JsonElement data = jsonObject.has("data") ? jsonObject.get("data") : jsonElement;
-
-        if (data.isJsonObject()) {
-            JsonObject dataObject = data.getAsJsonObject();
-            if (dataObject.has("content")) {
-                return dataObject.get("content");
-            }
-        }
-
-        return data;
-    }
-
-    private LaraApiException buildStreamingApiException(int status, JsonElement data) {
-        String type = "UnknownError";
-        String message = "An unknown error occurred";
-
-        if (data != null && data.isJsonObject()) {
-            JsonObject dataObject = data.getAsJsonObject();
-            JsonObject errorObject = dataObject.has("error") && dataObject.get("error").isJsonObject()
-                ? dataObject.getAsJsonObject("error")
-                : dataObject;
-
-            if (errorObject.has("type")) {
-                type = errorObject.get("type").getAsString();
-            }
-            if (errorObject.has("message")) {
-                message = errorObject.get("message").getAsString();
-            }
-        }
-
-        return new LaraApiException(status, type, message);
+        return new ClientResponse(gson, httpStatus, contentType, response);
     }
 
     // Helper method to read the error stream

--- a/src/main/java/com/translated/lara/translator/Translator.java
+++ b/src/main/java/com/translated/lara/translator/Translator.java
@@ -4,6 +4,7 @@ import com.translated.lara.Credentials;
 import com.translated.lara.errors.LaraApiException;
 import com.translated.lara.errors.LaraException;
 import com.translated.lara.net.ClientOptions;
+import com.translated.lara.net.ClientResponse;
 import com.translated.lara.net.HttpParams;
 import com.translated.lara.net.LaraClient;
 
@@ -36,12 +37,15 @@ public class Translator {
     public DetectResult detect(String text) throws LaraException {
         return detectAny(text, null, null);
     }
+
     public DetectResult detect(String text, String hint) throws LaraException {
         return detectAny(text, hint, null);
     }
+
     public DetectResult detect(String text, String hint, List<String> passlist) throws LaraException {
         return detectAny(text, hint, passlist);
     }
+
     public DetectResult detect(String text, String hint, String[] passlist) throws LaraException {
         return detectAny(text, hint, Arrays.asList(passlist));
     }
@@ -49,12 +53,15 @@ public class Translator {
     public DetectResult detect(String[] text) throws LaraException {
         return detectAny(text, null, null);
     }
+
     public DetectResult detect(String[] text, String hint) throws LaraException {
         return detectAny(text, hint, null);
     }
+
     public DetectResult detect(String[] text, String hint, List<String> passlist) throws LaraException {
         return detectAny(text, hint, passlist);
     }
+
     public DetectResult detect(String[] text, String hint, String[] passlist) throws LaraException {
         return detectAny(text, hint, Arrays.asList(passlist));
     }
@@ -62,12 +69,15 @@ public class Translator {
     public DetectResult detect(List<String> text) throws LaraException {
         return detectAny(text, null, null);
     }
+
     public DetectResult detect(List<String> text, String hint) throws LaraException {
         return detectAny(text, hint, null);
     }
+
     public DetectResult detect(List<String> text, String hint, List<String> passlist) throws LaraException {
         return detectAny(text, hint, passlist);
     }
+
     public DetectResult detect(List<String> text, String hint, String[] passlist) throws LaraException {
         return detectAny(text, hint, Arrays.asList(passlist));
     }
@@ -92,6 +102,7 @@ public class Translator {
     public TextResult translate(String text, String source, String target, TranslateOptions options) throws LaraException {
         return translateAny(text, source, target, options);
     }
+
     public TextResult translate(String text, String source, String target, TranslateOptions options, Consumer<TextResult> callback) throws LaraException {
         return translateAny(text, source, target, options, callback);
     }
@@ -103,6 +114,7 @@ public class Translator {
     public TextResult translate(List<String> text, String source, String target, TranslateOptions options) throws LaraException {
         return translateAny(text, source, target, options);
     }
+
     public TextResult translate(List<String> text, String source, String target, TranslateOptions options, Consumer<TextResult> callback) throws LaraException {
         return translateAny(text, source, target, options, callback);
     }
@@ -114,6 +126,7 @@ public class Translator {
     public TextResult translate(String[] text, String source, String target, TranslateOptions options) throws LaraException {
         return translateAny(text, source, target, options);
     }
+
     public TextResult translate(String[] text, String source, String target, TranslateOptions options, Consumer<TextResult> callback) throws LaraException {
         return translateAny(text, source, target, options, callback);
     }
@@ -125,6 +138,7 @@ public class Translator {
     public TextResult translateBlocks(List<TextBlock> text, String source, String target, TranslateOptions options) throws LaraException {
         return translateAny(text, source, target, options);
     }
+
     public TextResult translateBlocks(List<TextBlock> text, String source, String target, TranslateOptions options, Consumer<TextResult> callback) throws LaraException {
         return translateAny(text, source, target, options, callback);
     }
@@ -136,6 +150,7 @@ public class Translator {
     public TextResult translateBlocks(TextBlock[] text, String source, String target, TranslateOptions options) throws LaraException {
         return translateAny(text, source, target, options);
     }
+
     public TextResult translateBlocks(TextBlock[] text, String source, String target, TranslateOptions options, Consumer<TextResult> callback) throws LaraException {
         return translateAny(text, source, target, options, callback);
     }
@@ -162,29 +177,20 @@ public class Translator {
             }
         }
 
-        try (Stream<TextResult> responseStream = client.postAndGetStream("/translate", params
-                .set("source", source)
-                .set("target", target)
-                .set("q", text)
-                .build(),
+        try (Stream<ClientResponse> responseStream = client.postAndGetStream("/translate", params
+                        .set("source", source)
+                        .set("target", target)
+                        .set("q", text)
+                        .build(),
                 headers)) {
 
             TextResult lastResult = null;
-            Iterator<TextResult> iterator = responseStream.iterator();
-            while (true) {
-                try {
-                    if (!iterator.hasNext()) {
-                        break;
-                    }
-                    lastResult = iterator.next();
-                    if (callback != null) {
-                        callback.accept(lastResult);
-                    }
-                } catch (RuntimeException e) {
-                    if (e.getCause() instanceof LaraException) {
-                        throw (LaraException) e.getCause();
-                    }
-                    throw e;
+            Iterator<ClientResponse> iterator = responseStream.iterator();
+            while (iterator.hasNext()) {
+                lastResult = iterator.next().as(TextResult.class);
+
+                if (callback != null) {
+                    callback.accept(lastResult);
                 }
             }
 


### PR DESCRIPTION
Restructured `LaraClient` internals to remove hard-coded streaming responses, eliminate custom/duplicated parsing and error handling, and unify result processing for `postAndGetStream()` to align with `post()` behavior.